### PR TITLE
added .sln path to build and publish steps to deploy

### DIFF
--- a/.github/workflows/main_onecard.yml
+++ b/.github/workflows/main_onecard.yml
@@ -23,10 +23,10 @@ jobs:
           include-prerelease: true
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build app/OneCard.sln --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish app/OneCard.sln -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
with new deploy of web app for Linux, the deploy script was overwritten. Had to add the path to the .sln file for the build and publish steps again.